### PR TITLE
Update main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,18 +84,12 @@ class AdminPlugin(Star):
         self.msg_timestamps: dict[str, dict[str, deque[float]]] = defaultdict(
             lambda: defaultdict(lambda: deque(maxlen=self.min_count))
         )
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
-=======
         self.last_banned_time: dict[str, dict[str, float]] = defaultdict(
             lambda: defaultdict(float)
         )
->>>>>>> Stashed changes
-=======
         self.last_banned_time: dict[str, dict[str, float]] = defaultdict(
             lambda: defaultdict(float)
         )
->>>>>>> Stashed changes
 
         self.enable_audit: bool = self.config.get("enable_audit", False)
         self.admin_audit: bool = self.config.get("admin_audit", False)
@@ -443,19 +437,11 @@ class AdminPlugin(Star):
         user_id = event.get_sender_id()
         now = time.time()
 
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
-=======
-=======
->>>>>>> Stashed changes
         last_time = self.last_banned_time[group_id][user_id]
         if now - last_time < self.spamming_ban_time:
             return
 
-<<<<<<< Updated upstream
->>>>>>> Stashed changes
-=======
->>>>>>> Stashed changes
+
         timestamps = self.msg_timestamps[group_id][user_id]
         timestamps.append(now)
 
@@ -466,36 +452,26 @@ class AdminPlugin(Star):
                 all(interval < self.min_interval for interval in intervals)
                 and self.spamming_ban_time
             ):
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
-=======
+
                 # 提前写入禁止标记，防止并发重复禁
                 self.last_banned_time[group_id][user_id] = now
->>>>>>> Stashed changes
-=======
+
                 # 提前写入禁止标记，防止并发重复禁
                 self.last_banned_time[group_id][user_id] = now
->>>>>>> Stashed changes
+
                 try:
                     await event.bot.set_group_ban(
                         group_id=int(group_id),
                         user_id=int(user_id),
                         duration=self.spamming_ban_time,
                     )
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
-
                     yield event.plain_result(
                         f"检测到{get_nickname(event, user_id)}刷屏，已禁言"
                     )
-=======
                     nickname = await get_nickname(event, user_id)
                     yield event.plain_result(f"检测到{nickname}刷屏，已禁言")
->>>>>>> Stashed changes
-=======
                     nickname = await get_nickname(event, user_id)
                     yield event.plain_result(f"检测到{nickname}刷屏，已禁言")
->>>>>>> Stashed changes
                 except Exception as e:
                     logger.warning(f"刷屏禁言失败：{e}")
                 timestamps.clear()


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

清理 main.py 中的 Git 冲突标记，并通过整合重复的状态定义来简化垃圾信息封禁逻辑，并确保在发送封禁消息之前异步获取用户昵称。

增强功能：
- 移除 main.py 中残留的合并冲突标记和重复定义
- 通过统一 last_banned_time 初始化来整合垃圾信息封禁状态
- 等待 get_nickname，然后再产生封禁通知，以包含用户的昵称

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clean up Git conflict artifacts in main.py and streamline the spamming ban logic by consolidating duplicate state definitions and ensuring the user nickname is fetched asynchronously before sending ban messages.

Enhancements:
- Remove leftover merge conflict markers and duplicate definitions in main.py
- Consolidate spamming ban state by unifying last_banned_time initialization
- Await get_nickname before yielding ban notification to include the user's nickname

</details>