### PR TITLE
修复同意进群指令的bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -738,7 +738,7 @@ class AdminPlugin(Star):
         if not text:
             return "未引用任何【进群申请】"
         lines = text.split("\n")
-        if "【收到进群申请】" in text and len(lines) >= 5:
+        if "【收到进群申请】" in text and len(lines) >= 4:
             nickname = lines[1].split("：")[1]  # 第2行冒号后文本为nickname
             flag = lines[3].split("：")[1]  # 第4行冒号后文本为flag
             try:


### PR DESCRIPTION
原代码是处理逻辑是>=5，当他人进群申请没有备注进群理由时，因为实际只有4行，代码不做处理：
<img width="476" height="167" alt="20250813225236223" src="https://github.com/user-attachments/assets/74eed161-9380-4843-9a8e-77eeea2cc6d6" />
示例图
<img width="899" height="334" alt="20250813225029735" src="https://github.com/user-attachments/assets/e4b2b698-ff37-45df-849a-031364761433" />

现将5改成4，可以处理无进群备注理由的申请了：
<img width="897" height="211" alt="20250813225036788" src="https://github.com/user-attachments/assets/2270b9d5-791b-4bd6-88ab-5537d6f9e32a" />

## Summary by Sourcery

Bug 修复：
- 允许处理无理由的加入请求，通过将最小行数从 5 更改为 4

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Allow handling of join requests without a reason by changing the minimum line count from 5 to 4

</details>