### PR TITLE
feat: 增加群消息获取配置

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -629,5 +629,24 @@
         "default": "成员"
       }
     }
+  },
+  "query": {
+    "description": "历史消息查询配置",
+    "hint": "用于控制获取群聊历史消息的行为参数",
+    "type": "object",
+    "items": {
+      "query_rounds": {
+        "description": "查询回合数",
+        "hint": "获取群聊历史消息的循环次数，每次循环会获取一批消息",
+        "type": "int",
+        "default": 10
+      },
+      "query_counts": {
+        "description": "每回合消息数量",
+        "hint": "每次循环从群聊历史中获取的消息数量",
+        "type": "int",
+        "default": 200
+      }
+    }
   }
 }

--- a/core/llm_handle.py
+++ b/core/llm_handle.py
@@ -38,17 +38,17 @@ class LLMHandle:
         return contexts
 
     async def get_msg_contexts(
-        self, event: AiocqhttpMessageEvent, target_id: str, query_rounds: int = 10
+        self, event: AiocqhttpMessageEvent, target_id: str
     ) -> list[dict]:
         """持续获取群聊历史消息直到达到要求"""
         group_id = event.get_group_id()
         message_seq = 0
         contexts: list[dict] = []
-        for _ in range(query_rounds):
+        for _ in range(self.conf["query"]["query_rounds"]):
             payloads = {
                 "group_id": group_id,
                 "message_seq": message_seq,
-                "count": 200,
+                "count": self.conf["query"]["query_counts"],
                 "reverseOrder": True,
             }
             result: dict = await event.bot.api.call_action(
@@ -133,6 +133,6 @@ class LLMHandle:
             user_id=int(target_id),
             card=new_card,
         )
-        await event.send(event.plain_result(f"给{raw_card}取的新昵称：{new_card}"))
+        await event.send(event.plain_result(f"根据最近的{len(contexts)}条消息给'{raw_card}'取的新昵称：{new_card}"))
         await event.send(event.plain_result(f"理由：{reason}"))
         logger.info(f"已为 {target_id} 设置群昵称: {new_card}, 理由：{reason}")

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,6 +2,6 @@ name: astrbot_plugin_qqadmin # 这是你的插件的唯一识别名。
 display_name: QQ群管
 desc: "[仅aiocqhttp]群管插件，功能包括：禁言、全体禁言、踢人、拉黑、改群昵称、改头衔、设管理员、设精华、撤回消息、改群头像、改群名、发群公告、整理群友信息等等" # 插件简短描述
 help: 略  # 插件的帮助信息
-version: v3.2.0 # 插件版本号。格式：v1.1.1 或者 v1.1
+version: v3.2.1 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: Zhalslar # 作者
 repo: https://github.com/Zhalslar/astrbot_plugin_qqadmin # 插件的仓库地址


### PR DESCRIPTION
fix https://github.com/Zhalslar/astrbot_plugin_qqadmin/issues/54
通过自定义群消息获取配置避免默认配置过大导致请求失败

## Sourcery 总结

在LLM处理器中，对群组消息历史记录获取应用用户可配置的限制，以避免默认过载；调整响应消息以报告上下文使用情况；并相应地更新插件版本

新功能：
- 引入可自定义的群组消息历史记录检索配置参数（查询轮次和数量）

错误修复：
- 通过将硬编码的消息获取限制替换为用户可配置的设置来防止API请求失败

改进：
- 更新ai_set_card响应，以包含用于昵称生成的上下文消息数量

构建：
- 将插件版本从v3.2.0提升到v3.2.1

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Apply user-configurable limits to group message history fetching in the LLM handler to avoid default overloads, adjust response messaging to report context usage, and update the plugin version accordingly

New Features:
- Introduce customizable configuration parameters for group message history retrieval (query rounds and counts)

Bug Fixes:
- Prevent API request failures by replacing hardcoded message fetch limits with user-configurable settings

Enhancements:
- Update ai_set_card response to include the number of context messages used for nickname generation

Build:
- Bump plugin version from v3.2.0 to v3.2.1

</details>