### PR TITLE
feat: 支持分群配置进群审核

### DIFF
--- a/main.py
+++ b/main.py
@@ -236,6 +236,16 @@ class QQAdminPlugin(Star):
         await self.curfew.stop_curfew(event)
 
 
+    @filter.command("设置进群审核", desc="设置本群进群审核开关（开/关/清除）")
+    @perm_required(PermLevel.SUPERUSER)
+    async def set_join_review(self, event: AiocqhttpMessageEvent):
+        await self.join.set_join_review(event)
+
+    @filter.command("查看进群审核", desc="查看本群进群审核开关状态", alias={"进群审核"})
+    @perm_required(PermLevel.SUPERUSER)
+    async def view_join_review(self, event: AiocqhttpMessageEvent):
+        await self.join.view_join_review(event)
+
     @filter.command("添加进群关键词", desc="添加自动批准进群的关键词")
     @perm_required(PermLevel.ADMIN)
     async def add_accept_keyword(self, event: AiocqhttpMessageEvent):


### PR DESCRIPTION
支持为每个群单独配置入群审核（audit）的开启或关闭，当未设置时回退到全局配置。
在我其他commit基础上弄的，懒得分离了，等其他合入了再合入

## 由 Sourcery 提供的摘要

添加按群组配置的加入审核开关（可回退到全局审核设置），并将其接入入群申请处理流程和管理员命令中。

新功能：
- 允许为每个群组单独配置加入审核开启或关闭，并在未配置时回退到全局设置。
- 提供管理员命令，用于设置、清除和查看群组的加入审核状态。

改进：
- 将每个群组的加入审核配置与现有的群组加入数据一同持久化存储，并在决定是否审核入群请求时使用该配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add per-group join review toggles that fall back to a global audit setting and wire them into join request handling and admin commands.

New Features:
- Allow configuring join review on or off per group with fallback to the global setting.
- Expose admin commands to set, clear, and view a group’s join review status.

Enhancements:
- Persist per-group join review configuration alongside existing group join data and use it when deciding whether to audit join requests.

</details>