### PR TITLE
fix: 处理进群申请时提取答案部分

### DIFF
--- a/core/join_handle.py
+++ b/core/join_handle.py
@@ -174,6 +174,11 @@ class JoinHandle:
             return False, f"QQ等级过低({user_level}<{min_level})"
 
         if comment:
+            # 提取答案部分
+            keyword = "\n答案："
+            if keyword in comment:
+                comment = comment.split(keyword, 1)[1]
+
             lower_comment = comment.lower()
             # 3.命中进群黑词
             rkws = await self.db.get_reject_words(group_id)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 确保在评估拒绝关键词时，仅使用加入请求评论中的“回答”部分，从而避免被错误拒绝的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure only the answer portion of a join request comment is used when evaluating rejection keywords to avoid false rejections.

</details>