### PR TITLE
Handle hidden QQ level in join verification

### DIFF
--- a/core/join_handle.py
+++ b/core/join_handle.py
@@ -208,6 +208,8 @@ class JoinHandle:
         min_level = await self.db.get(gid, "join_min_level")
         if min_level > 0 and user_level is not None and user_level < min_level:
             return False, f"QQ等级过低({user_level}<{min_level})"
+        if user_level is None:
+            return False, f"开启了隐藏QQ等级,请关闭隐藏等级重新申请"
 
         if comment:
             # 提取答案部分


### PR DESCRIPTION
修复"当user_level=None，且命中白词会返回True，导致等级低，但是开启隐藏等级的可以进群"。

## Summary by Sourcery

错误修复：
- 防止 QQ 等级被隐藏的用户在群验证时绕过最低等级限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent users with hidden QQ levels from bypassing minimum level restrictions during group join verification.

</details>