### PR TITLE
up

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -559,7 +559,7 @@
           "高等级成员",
           "成员"
         ],
-        "default": "高等级成员"
+        "default": "成员"
       },
       "ai_set_title": {
         "description": "取头衔",
@@ -571,7 +571,7 @@
           "高等级成员",
           "成员"
         ],
-        "default": "管理员"
+        "default": "成员"
       },
       "set_config": {
         "description": "群管配置",

--- a/main.py
+++ b/main.py
@@ -416,13 +416,17 @@ class QQAdminPlugin(Star):
             yield r
 
     @filter.command("取名")
-    @perm_required(PermLevel.ADMIN, check_at=False)
+    @perm_required(
+        PermLevel.MEMBER, check_at=False
+    )  # 仅要求Bot为成员，实际权限不足时忽略接口报错
     async def ai_set_card(self, event: AiocqhttpMessageEvent):
         """取名@群友 <消息轮数>"""
         await self.llm.ai_set_card(event)
 
     @filter.command("取头衔")
-    @perm_required(PermLevel.OWNER, check_at=False)
+    @perm_required(
+        PermLevel.MEMBER, check_at=False
+    )  # 仅要求Bot为成员，实际权限不足时忽略接口报错
     async def ai_set_title(self, event: AiocqhttpMessageEvent):
         """取名@群友 <消息轮数>"""
         await self.llm.ai_set_title(event)

--- a/permission.py
+++ b/permission.py
@@ -158,6 +158,7 @@ def perm_required(
     权限检查装饰器。
     :param perm_key: 可选。用户执行命令所需的最低权限键名，默认使用被装饰函数的函数名。
     :param bot_perm: Bot 执行此命令所需的最低权限等级。
+    :param check_at: 是否检查“是否有权对被@者实施操作”。
     """
 
     def decorator(


### PR DESCRIPTION
## Summary by Sourcery

优化聊天记录的收集方式，以及发送给 LLM 用于生成基于用户的群昵称和头衔的流程，同时放宽指令权限要求，并在机器人权限不足时进行更为友好的处理。

增强点：
- 修改聊天记录提取逻辑，在调用 LLM 之前，将聊天记录转换为纯文本行并拼接为单一的聊天记录字符串。
- 将昵称和头衔生成逻辑统一到一个共享的辅助函数中，用于记录操作日志、发送一致的响应，并在机器人没有权限设置名称时安全地忽略失败。
- 调整 LLM 提示词，将完整的文本聊天记录以内联方式包含在提示中，以提供更好的上下文。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine how chat history is collected and sent to the LLM for generating user-based group nicknames and titles, and relax command permission requirements while handling insufficient bot permissions gracefully.

Enhancements:
- Change chat history extraction to return plain text lines joined into a single chat history string before invoking the LLM.
- Unify nickname and title generation into a shared helper that logs actions, sends consistent responses, and safely ignores failures when the bot lacks permission to set names.
- Adjust the LLM prompt to include the full textual chat history inline for better context.

</details>