### PR TITLE
feat: 引入强类型配置

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,164 @@
+# config.py
+from __future__ import annotations
+
+from pathlib import Path
+from collections.abc import Mapping, MutableMapping
+import random
+from types import MappingProxyType, UnionType
+from typing import Any, Union, get_args, get_origin, get_type_hints
+
+from astrbot.api import logger
+from astrbot.core.config.astrbot_config import AstrBotConfig
+from astrbot.core.star.context import Context
+from astrbot.core.star.star_tools import StarTools
+from astrbot.core.utils.astrbot_path import get_astrbot_plugin_path
+
+
+class ConfigNode:
+    """
+    配置节点, 把 dict 变成强类型对象。
+
+    规则：
+    - schema 来自子类类型注解
+    - 声明字段：读写，写回底层 dict
+    - 未声明字段和下划线字段：仅挂载属性，不写回
+    - 支持 ConfigNode 多层嵌套（lazy + cache）
+    """
+
+    _SCHEMA_CACHE: dict[type, dict[str, type]] = {}
+    _FIELDS_CACHE: dict[type, set[str]] = {}
+
+    @classmethod
+    def _schema(cls) -> dict[str, type]:
+        return cls._SCHEMA_CACHE.setdefault(cls, get_type_hints(cls))
+
+    @classmethod
+    def _fields(cls) -> set[str]:
+        return cls._FIELDS_CACHE.setdefault(
+            cls,
+            {k for k in cls._schema() if not k.startswith("_")},
+        )
+
+    @staticmethod
+    def _is_optional(tp: type) -> bool:
+        if get_origin(tp) in (Union, UnionType):
+            return type(None) in get_args(tp)
+        return False
+
+    def __init__(self, data: MutableMapping[str, Any]):
+        object.__setattr__(self, "_data", data)
+        object.__setattr__(self, "_children", {})
+        for key, tp in self._schema().items():
+            if key.startswith("_"):
+                continue
+            if key in data:
+                continue
+            if hasattr(self.__class__, key):
+                continue
+            if self._is_optional(tp):
+                continue
+            logger.warning(f"[config:{self.__class__.__name__}] 缺少字段: {key}")
+
+    def __getattr__(self, key: str) -> Any:
+        if key in self._fields():
+            value = self._data.get(key)
+            tp = self._schema().get(key)
+
+            if isinstance(tp, type) and issubclass(tp, ConfigNode):
+                children: dict[str, ConfigNode] = self.__dict__["_children"]
+                if key not in children:
+                    if not isinstance(value, MutableMapping):
+                        raise TypeError(
+                            f"[config:{self.__class__.__name__}] "
+                            f"字段 {key} 期望 dict，实际是 {type(value).__name__}"
+                        )
+                    children[key] = tp(value)
+                return children[key]
+
+            return value
+
+        if key in self.__dict__:
+            return self.__dict__[key]
+
+        raise AttributeError(key)
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        if key in self._fields():
+            self._data[key] = value
+            return
+        object.__setattr__(self, key, value)
+
+    def raw_data(self) -> Mapping[str, Any]:
+        """
+        底层配置 dict 的只读视图
+        """
+        return MappingProxyType(self._data)
+
+    def save_config(self) -> None:
+        """
+        保存配置到磁盘（仅允许在根节点调用）
+        """
+        if not isinstance(self._data, AstrBotConfig):
+            raise RuntimeError(
+                f"{self.__class__.__name__}.save_config() 只能在根配置节点上调用"
+            )
+        self._data.save_config()
+
+
+# ============ 插件自定义配置 ==================
+
+
+class VoteBanConfig(ConfigNode):
+    ttl: bool
+    threshold: int
+
+
+class PluginConfig(ConfigNode):
+    divided_manage: bool
+    default: dict
+    admin_audit: bool
+    random_ban_time: str
+    vote_ban: VoteBanConfig
+    llm_get_msg_count: int
+    level_threshold: int
+    perms: dict
+
+    _db_version = 3
+    _plugin_name: str = "astrbot_plugin_qqadmin"
+
+    def __init__(self, cfg: AstrBotConfig, context: Context):
+        super().__init__(cfg)
+        self.context = context
+        self.admins_id = self._clean_ids(context.get_config().get("admins_id", []))
+
+        self.data_dir = StarTools.get_data_dir(self._plugin_name)
+        self.plugin_dir = Path(get_astrbot_plugin_path()) / self._plugin_name
+
+        self.db_path = self.data_dir / f"qqadmin_data_v{self._db_version}.db"
+        self.ban_lexicon_path = self.plugin_dir / "SensitiveLexicon.json"
+        self.group_notice_dir = self.data_dir / "group_notice"
+        self.group_notice_dir.mkdir(parents=True, exist_ok=True)
+        self.curfew_file = self.data_dir / "curfew_data.json"
+        if not self.curfew_file.exists():
+            self.curfew_file.write_text("{}", encoding="utf-8")
+        self.file_dir = self.data_dir / "file"
+        self.file_dir.mkdir(parents=True, exist_ok=True)
+
+        # 随机禁言时间范围(最大值不超过一个月, 即2592000秒)
+        min_ban_time, max_ban_time = map(int, self.random_ban_time.split("~"))
+        self.min_ban_time = max(min_ban_time, 1)
+        self.max_ban_time = min(max_ban_time, 2592000)
+        self.spamming_count = 5
+        self.spamming_interval = 0.5
+
+    @staticmethod
+    def _clean_ids(ids: list) -> list[str]:
+        """过滤并规范化数字 ID"""
+        return [str(i) for i in ids if str(i).isdigit()]
+
+    def get_ban_time(self, seconds=None) -> int:
+        """获取禁言时间"""
+        if not seconds or not isinstance(seconds, int):
+            return random.randint(self.min_ban_time, self.max_ban_time)
+        else:
+            return min(max(seconds, self.min_ban_time), self.max_ban_time)

--- a/config.py
+++ b/config.py
@@ -109,7 +109,7 @@ class ConfigNode:
 
 
 class VoteBanConfig(ConfigNode):
-    ttl: bool
+    ttl: int
     threshold: int
 
 

--- a/core/file_handle.py
+++ b/core/file_handle.py
@@ -1,7 +1,6 @@
 import os
 import re
 from datetime import datetime
-from pathlib import Path
 
 from astrbot.api import logger
 from astrbot.core.message.components import File, Image, Reply, Video
@@ -10,11 +9,12 @@ from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
 )
 
 from ..utils import download_file
+from ..config import PluginConfig
 
 
 class FileHandle:
-    def __init__(self, data_dir: Path):
-        self.data_dir = data_dir
+    def __init__(self, config: PluginConfig):
+        self.data_dir = config.file_dir
 
     async def _parse_path(
         self, event: AiocqhttpMessageEvent, path: str
@@ -169,7 +169,7 @@ class FileHandle:
             if url := getattr(seg, "url", None) or getattr(seg, "file", None):
                 logger.info(f"正在从URL下载文件：{url}")
                 file_path = self.data_dir / file_name
-                await download_file(url, str(file_path))
+                await download_file(url, file_path)
                 if os.path.exists(file_path):
                     return file_path
                 logger.error(f"下载文件失败：{url}")

--- a/core/llm_handle.py
+++ b/core/llm_handle.py
@@ -4,18 +4,18 @@ from typing import Any
 
 from astrbot import logger
 from astrbot.api.star import Context
-from astrbot.core.config.astrbot_config import AstrBotConfig
 from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
     AiocqhttpMessageEvent,
 )
 
 from ..utils import get_ats, get_nickname
+from ..config import PluginConfig
 
 
 class LLMHandle:
-    def __init__(self, context: Context, config: AstrBotConfig):
+    def __init__(self, context: Context, config: PluginConfig):
         self.context = context
-        self.conf = config
+        self.cfg = config
 
     def _build_user_context(
         self, round_messages: list[dict[str, Any]], target_id: str
@@ -105,9 +105,7 @@ class LLMHandle:
         at_ids = get_ats(event)
         target_id = at_ids[0] if at_ids else event.get_sender_id()
         end_arg = event.message_str.split()[-1]
-        query_rounds = (
-            int(end_arg) if end_arg.isdigit() else self.conf["llm_get_msg_count"]
-        )
+        query_rounds = int(end_arg) if end_arg.isdigit() else self.cfg.llm_get_msg_count
         raw_card = await get_nickname(event, target_id)
         return target_id, raw_card, query_rounds
 

--- a/core/notice_handle.py
+++ b/core/notice_handle.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import os
 import textwrap
 from datetime import datetime
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from astrbot.api import logger
@@ -12,14 +10,15 @@ from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
 )
 
 from ..utils import download_file, extract_image_url
+from ..config import PluginConfig
 
 if TYPE_CHECKING:
     from ..main import QQAdminPlugin
 
 class NoticeHandle:
-    def __init__(self, plugin: QQAdminPlugin, data_dir: Path):
+    def __init__(self, plugin: QQAdminPlugin, config: PluginConfig):
         self.plugin = plugin
-        self.data_dir = data_dir
+        self.cfg = config
 
     async def send_group_notice(self, event: AiocqhttpMessageEvent):
         """(引用图片)发布群公告 xxx"""
@@ -27,12 +26,12 @@ class NoticeHandle:
         if not content:
             await event.send(event.plain_result("你又不说要发什么群公告"))
             return
+        gid = event.get_group_id()
         image_path = None
         if image_url := extract_image_url(chain=event.get_messages()):
-            temp_path = os.path.join(
-                self.data_dir,
-                f"group_notice_image_{datetime.now().strftime('%Y%m%d_%H%M%S')}.png",
-            )
+            img_name = f"{gid}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.png"
+            temp_path = self.cfg.group_notice_dir / img_name
+
             logger.debug("temp_path:", temp_path)
             image_path = await download_file(image_url, temp_path)
             if not image_path:

--- a/data.py
+++ b/data.py
@@ -1,14 +1,12 @@
 import asyncio
 import json
-from pathlib import Path
 
 import aiosqlite
 
 from astrbot.api import logger
-from astrbot.core.config.astrbot_config import AstrBotConfig
 
 from .utils import parse_bool
-
+from .config import PluginConfig
 
 class QQAdminDB:
     """
@@ -39,11 +37,11 @@ class QQAdminDB:
 
     # ================================================================
 
-    def __init__(self, config: AstrBotConfig, db_path: Path):
-        self.db_path = db_path
+    def __init__(self, config: PluginConfig):
+        self.db_path = config.db_path
 
         # 默认字段（动态配置核心）
-        self.default_cfg: dict = config["default"]
+        self.default_cfg: dict = config.default
 
         self._conn = None
         self._cache = {}

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime
+from pathlib import Path
 
 from aiohttp import ClientSession
 
@@ -165,7 +166,7 @@ def format_time(timestamp):
     return datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d")
 
 
-async def download_file(url: str, save_path: str) -> str | None:
+async def download_file(url: str, save_path: Path) -> Path | None:
     """下载文件并保存到本地"""
     url = url.replace("https://", "http://")
     try:


### PR DESCRIPTION
## Summary by Sourcery

引入强类型的插件配置系统，并重构 QQAdmin 插件，使其在权限管理、数据库、处理器和工具函数等部分统一使用该配置系统。

新功能：
- 在 `AstrBotConfig` 之上新增 `ConfigNode/PluginConfig` 类型化配置层，包括派生路径以及诸如 `get_ban_time` 等辅助方法。

缺陷修复：
- 加强对未初始化权限管理器和缺失配置字段的处理，避免运行时错误。

增强改进：
- 将 `PermissionManager` 从单例模式重构为使用基于 `PluginConfig` 初始化的模块级实例。
- 更新所有处理器类（普通、封禁、入群、宵禁、通知、llm、文件）以及 `QQAdminDB`，使其依赖 `PluginConfig`，而不是原始的 `AstrBotConfig` 和手动路径处理。
- 在 `PluginConfig` 工具中简化并集中封禁时间、垃圾信息检测、投票封禁、文件路径和管理员 ID 的逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a strongly-typed plugin configuration system and refactor the QQAdmin plugin to consume it across permission management, database, handlers, and utilities.

New Features:
- Add a ConfigNode/PluginConfig typed configuration layer over AstrBotConfig, including derived paths and helper methods like get_ban_time.

Bug Fixes:
- Harden handling of uninitialized permission manager and missing configuration fields to avoid runtime errors.

Enhancements:
- Refactor PermissionManager away from a singleton pattern to use a module-level instance initialized with PluginConfig.
- Update all handler classes (normal, ban, join, curfew, notice, llm, file) and QQAdminDB to depend on PluginConfig instead of raw AstrBotConfig and manual path handling.
- Simplify and centralize ban-time, spam detection, vote-ban, file-path, and admin ID logic into PluginConfig utilities.

</details>