### PR TITLE
入群欢迎词支持@和图片的cq码

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -78,7 +78,7 @@
       },
       "join_welcome": {
         "description": "进群欢迎词",
-        "hint": "发给新群友的欢迎词, 支持变量: {nickname}, 示例：欢迎{nickname}加入群聊",
+        "hint": "发给新群友的欢迎词, 支持@和图片cq码，支持变量: {nickname}、{qq}, 示例：[CQ:at,qq={qq}] 欢迎{nickname}加入群聊",
         "type": "string",
         "default": ""
       },

--- a/core/join_handle.py
+++ b/core/join_handle.py
@@ -340,7 +340,7 @@ class JoinHandle:
             join_welcome = await self.db.get(gid, "join_welcome")
             if join_welcome:
                 nickname = await get_nickname(event, uid)
-                welcome = join_welcome.format(nickname=nickname)
+                welcome = join_welcome.replace("{nickname}", nickname).replace("{qq}", uid)
                 chain = MessageChain(chain=parse_cq_to_chain(welcome))
                 await event.send(chain)
             # 进群禁言

--- a/core/join_handle.py
+++ b/core/join_handle.py
@@ -1,6 +1,9 @@
 from aiocqhttp import CQHttp
 
+from .parse_cq_to_chain import parse_cq_to_chain
 from astrbot.api import logger
+from astrbot.api.event import MessageChain
+from astrbot.core.config.astrbot_config import AstrBotConfig
 from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
     AiocqhttpMessageEvent,
 )
@@ -338,7 +341,8 @@ class JoinHandle:
             if join_welcome:
                 nickname = await get_nickname(event, uid)
                 welcome = join_welcome.format(nickname=nickname)
-                await event.send(event.plain_result(welcome))
+                chain = MessageChain(chain=parse_cq_to_chain(welcome))
+                await event.send(chain)
             # 进群禁言
             join_ban_time = await self.db.get(gid, "join_ban_time")
             if join_ban_time > 0:

--- a/core/parse_cq_to_chain.py
+++ b/core/parse_cq_to_chain.py
@@ -1,0 +1,88 @@
+import re
+import os
+# from astrbot.core.message.components import Plain, At, Image
+
+def parse_cq_to_chain(text: str) -> list:
+    """增强版 CQ 码解析，支持本地绝对路径图片"""
+    chain = []
+    # 更加健壮的正则，支持参数中带有路径、空格等
+    pattern = r'\[CQ:([a-z]+),([^\]]+)\]'
+    last_pos = 0
+    
+    for match in re.finditer(pattern, text):
+        # 处理之前的纯文本
+        plain_text = text[last_pos:match.start()]
+        if plain_text:
+            chain.append(Plain(plain_text))
+        
+        cq_type = match.group(1)
+        params_str = match.group(2)
+        
+        # 解析参数：file=D:\xxx...
+        params = {}
+        for item in params_str.split(','):
+            if '=' in item:
+                k, v = item.split('=', 1)
+                params[k.strip()] = v.strip()
+        
+        # 根据类型构造组件
+        if cq_type == "at":
+            chain.append(At(qq=params.get("qq", ""), name=""))
+        elif cq_type == "image":
+            file_path = params.get("file") or params.get("url")
+            if file_path:
+                # 判断是 URL 还是本地路径
+                if file_path.startswith("http"):
+                    chain.append(Image.fromURL(file_path))
+                else:
+                    # 确保路径存在
+                    if os.path.exists(file_path):
+                        chain.append(Image.fromFileSystem(file_path))
+                    else:
+                        # 如果路径不存在，回退为文本提示，方便调试
+                        chain.append(Plain(f"[图片读取失败: {file_path}]"))
+        
+        last_pos = match.end()
+    
+    # 处理剩余文本
+    rest_text = text[last_pos:]
+    if rest_text:
+        chain.append(Plain(rest_text))
+        
+    return chain
+
+# --- 以下仅用于本地脱离 AstrBot 环境测试 ---
+# if __name__ == "__main__":
+#     class MockComponent:
+#         def __repr__(self): 
+#             # 这样打印出来能看到具体的属性
+#             return f"{self.__class__.__name__}({self.__dict__})"
+    
+#     class Plain(MockComponent): 
+#         def __init__(self, text): self.text = text
+        
+#     class At(MockComponent): 
+#         def __init__(self, qq, name=""): 
+#             self.qq = qq
+#             self.name = name
+
+#     class Image(MockComponent): 
+#         def __init__(self, file=None, url=None):
+#             self.file = file
+#             self.url = url
+#         @staticmethod
+#         def fromURL(url): return Image(url=url)
+#         @staticmethod
+#         def fromFileSystem(path): return Image(file=path)
+
+#     # 测试文本（建议使用 r"" 原始字符串防止路径转义）
+#     test_text = r"你好 {nickname}。欢迎！[CQ:at,qq=123456][CQ:image,file=./入群欢迎.jpg]"
+    
+#     # 假设你脚本里的函数名是 parse_cq_to_chain
+#     result = parse_cq_to_chain(test_text)
+    
+#     print("\n" + "="*30)
+#     print("--- 🔍 解析结果验证 ---")
+#     for i, item in enumerate(result):
+#         print(f"组件 {i}: {item}")
+#     print("="*30)

--- a/core/parse_cq_to_chain.py
+++ b/core/parse_cq_to_chain.py
@@ -1,6 +1,6 @@
 import re
 import os
-# from astrbot.core.message.components import Plain, At, Image
+from astrbot.core.message.components import Plain, At, Image
 
 def parse_cq_to_chain(text: str) -> list:
     """增强版 CQ 码解析，支持本地绝对路径图片"""


### PR DESCRIPTION
1、如题
2、增加了uid替换{qq}，format改成了replace避免不存在“{nickname}”时报错
https://github.com/Zhalslar/astrbot_plugin_qqadmin/issues/94

## Summary by Sourcery

通过将格式化文本转换为消息链，在群欢迎消息中支持基于 CQ 码的提及和图片。

新功能：
- 在欢迎消息中添加 CQ 码解析，以渲染 @ 提及和图片，并支持 URL 和本地文件路径。

增强：
- 优化入群欢迎消息的发送方式，改为使用构造的 MessageChain 而非纯文本消息，以支持更丰富的内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support CQ code-based mentions and images in group join welcome messages by converting formatted text into a message chain.

New Features:
- Add parsing of CQ codes in welcome messages to render @ mentions and images, including support for both URLs and local file paths.

Enhancements:
- Refine join welcome sending to use a constructed MessageChain instead of plain text messages for richer content.

</details>