### PR TITLE
fix: 修复私聊会话无法批准进群申请

### DIFF
--- a/main.py
+++ b/main.py
@@ -312,12 +312,12 @@ class QQAdminPlugin(Star):
         await self.join.handle_block_ids(event)
 
     @filter.command("批准", alias={"同意进群"}, desc="批准进群申请")
-    @perm_required(PermLevel.ADMIN, perm_key="approve")
+    @perm_required(PermLevel.ADMIN, perm_key="approve", allow_private=True)
     async def agree_add_group(self, event: AiocqhttpMessageEvent, extra: str = ""):
         await self.join.agree_add_group(event, extra)
 
     @filter.command("驳回", alias={"拒绝进群", "不批准"}, desc="驳回进群申请")
-    @perm_required(PermLevel.ADMIN, perm_key="approve")
+    @perm_required(PermLevel.ADMIN, perm_key="approve", allow_private=True)
     async def refuse_add_group(self, event: AiocqhttpMessageEvent, extra: str = ""):
         await self.join.refuse_add_group(event, extra)
 

--- a/permission.py
+++ b/permission.py
@@ -135,7 +135,7 @@ def perm_required(
     权限检查装饰器。
     :param perm_key: 可选。用户执行命令所需的最低权限键名，默认使用被装饰函数的函数名。
     :param bot_perm: Bot 执行此命令所需的最低权限等级。
-    :param check_at: 是否检查”是否有权对被@者实施操作”。
+    :param check_at: 是否检查“是否有权对被@者实施操作”。
     :param allow_private: 是否允许在私信中执行。
     """
 

--- a/permission.py
+++ b/permission.py
@@ -129,12 +129,14 @@ def perm_required(
     bot_perm: PermLevel = PermLevel.ADMIN,
     perm_key: str | None = None,
     check_at: bool = True,
+    allow_private: bool = False,
 ):
     """
     权限检查装饰器。
     :param perm_key: 可选。用户执行命令所需的最低权限键名，默认使用被装饰函数的函数名。
     :param bot_perm: Bot 执行此命令所需的最低权限等级。
-    :param check_at: 是否检查“是否有权对被@者实施操作”。
+    :param check_at: 是否检查”是否有权对被@者实施操作”。
+    :param allow_private: 是否允许在私信中执行。
     """
 
     def decorator(
@@ -154,8 +156,17 @@ def perm_required(
             if event.platform_meta.name != "aiocqhttp":
                 return
 
-            # 仅限群聊
+            # 私信处理
             if event.is_private_chat():
+                if not allow_private:
+                    return
+                if inspect.isasyncgenfunction(func):
+                    async for item in func(plugin_instance, event, *args, **kwargs):
+                        yield item
+                else:
+                    await cast(
+                        Awaitable[Any], func(plugin_instance, event, *args, **kwargs)
+                    )
                 return
 
             # 权限管理未初始化


### PR DESCRIPTION
解决 #95 所示问题。

## Summary by Sourcery

允许在明确启用时在私聊中运行需要权限检查的指令，并将其应用到群组加群审批指令。

New Features:
- 在权限装饰器中新增选项，用于允许在私聊中执行特定指令。

Bug Fixes:
- 修复无法在私聊会话中通过或拒绝群组加群请求的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow permission-checked commands to run in private chats when explicitly enabled and apply this to group join approval commands.

New Features:
- Add an option to the permission decorator to allow executing certain commands in private chats.

Bug Fixes:
- Fix inability to approve or reject group join requests from private chat sessions.

</details>