### PR TITLE
feat: 群列表新增bot群身份标识

### DIFF
--- a/group_info_cache.py
+++ b/group_info_cache.py
@@ -13,6 +13,13 @@ from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_platform_adapter import (
 
 from .data import QQAdminDB
 
+BOT_ROLE_PRIORITY = {
+    "owner": 0,
+    "admin": 1,
+    "member": 2,
+    "unknown": 2,
+}
+
 
 class QQGroupInfoCache:
     def __init__(
@@ -26,14 +33,26 @@ class QQGroupInfoCache:
         self.ttl_seconds = ttl_seconds
 
         self._lock = asyncio.Lock()
+        self._bot_role_lock = asyncio.Lock()
         self._last_refresh_at = 0.0
         self._group_list_cache: list[dict[str, Any]] = []
         self._group_detail_cache: dict[str, dict[str, Any]] = {}
         self._group_clients: dict[str, Any] = {}
+        self._bot_role_cache: dict[str, str] = {}
+        self._client_bot_ids: dict[int, str] = {}
 
     async def list_groups(self, force: bool = False) -> list[dict[str, Any]]:
         if force or not self._is_fresh() or not self._group_list_cache:
             await self._refresh_group_list(force=force)
+        return copy.deepcopy(self._group_list_cache)
+
+    async def list_groups_with_bot_roles(
+        self,
+        force_bot_roles: bool = False,
+    ) -> list[dict[str, Any]]:
+        if not self._is_fresh() or not self._group_list_cache:
+            await self._refresh_group_list(force=False)
+        await self._hydrate_bot_roles(force=force_bot_roles)
         return copy.deepcopy(self._group_list_cache)
 
     async def get_group(self, group_id: str, force: bool = False) -> dict[str, Any]:
@@ -74,6 +93,7 @@ class QQGroupInfoCache:
         ]
         self._group_detail_cache.pop(normalized_group_id, None)
         self._group_clients.pop(normalized_group_id, None)
+        self._bot_role_cache.pop(normalized_group_id, None)
 
     def _is_fresh(self) -> bool:
         return (time.time() - self._last_refresh_at) < self.ttl_seconds
@@ -111,7 +131,9 @@ class QQGroupInfoCache:
                     merged_groups, group_clients, missing_detail_group_ids
                 )
 
-            self._group_list_cache = self._sort_groups(list(merged_groups.values()))
+            groups = list(merged_groups.values())
+            self._attach_cached_bot_roles(groups)
+            self._group_list_cache = self._sort_groups(groups)
             self._group_clients = group_clients
             self._group_detail_cache.clear()
             self._last_refresh_at = time.time()
@@ -152,21 +174,7 @@ class QQGroupInfoCache:
         group_id: str,
         preferred_client: Any | None = None,
     ) -> tuple[dict[str, Any] | None, Any | None]:
-        tried_client_ids: set[int] = set()
-        clients: list[Any] = []
-
-        if preferred_client is not None:
-            clients.append(preferred_client)
-            tried_client_ids.add(id(preferred_client))
-
-        for client in self._iter_clients():
-            client_id = id(client)
-            if client_id in tried_client_ids:
-                continue
-            tried_client_ids.add(client_id)
-            clients.append(client)
-
-        for client in clients:
+        for client in self._build_client_priority_list(preferred_client):
             try:
                 result = await client.call_action(
                     "get_group_info", group_id=int(group_id)
@@ -182,6 +190,110 @@ class QQGroupInfoCache:
                 )
 
         return None, None
+
+    async def _hydrate_bot_roles(self, force: bool = False) -> None:
+        async with self._bot_role_lock:
+            groups = [
+                group
+                for group in self._group_list_cache
+                if str(group.get("group_id", "")).strip()
+            ]
+            if not groups:
+                return
+
+            semaphore = asyncio.Semaphore(8)
+
+            async def load_role(group: dict[str, Any]) -> None:
+                group_id = str(group.get("group_id", "")).strip()
+                if not group_id:
+                    return
+                if not force and group_id in self._bot_role_cache:
+                    return
+
+                async with semaphore:
+                    role, client = await self._fetch_bot_role(
+                        group_id,
+                        preferred_client=self._group_clients.get(group_id),
+                    )
+                    self._bot_role_cache[group_id] = role
+                    if client is not None:
+                        self._group_clients[group_id] = client
+
+            await asyncio.gather(*(load_role(group) for group in groups))
+            self._attach_cached_bot_roles(self._group_list_cache)
+            self._group_list_cache = self._sort_groups(self._group_list_cache)
+
+    async def _fetch_bot_role(
+        self,
+        group_id: str,
+        preferred_client: Any | None = None,
+    ) -> tuple[str, Any | None]:
+        for client in self._build_client_priority_list(preferred_client):
+            bot_id = await self._get_client_bot_id(client)
+            if not bot_id or not bot_id.isdigit():
+                continue
+
+            try:
+                result = await client.call_action(
+                    "get_group_member_info",
+                    group_id=int(group_id),
+                    user_id=int(bot_id),
+                    no_cache=True,
+                )
+                info = self._extract_object(result)
+                if not info:
+                    continue
+                return self._normalize_bot_role(info.get("role")), client
+            except Exception as exc:
+                logger.debug("Failed to fetch bot role for %s: %s", group_id, exc)
+
+        return "unknown", None
+
+    async def _get_client_bot_id(self, client: Any) -> str:
+        client_key = id(client)
+        cached_bot_id = self._client_bot_ids.get(client_key)
+        if cached_bot_id:
+            return cached_bot_id
+
+        bot_id = ""
+        try:
+            result = await client.call_action("get_login_info")
+            info = self._extract_object(result)
+            bot_id = str(info.get("user_id", "")).strip()
+        except Exception:
+            try:
+                info = await client.get_login_info() or {}
+                bot_id = str(info.get("user_id", "")).strip()
+            except Exception as exc:
+                logger.debug("Failed to fetch bot self id: %s", exc)
+
+        if bot_id:
+            self._client_bot_ids[client_key] = bot_id
+        return bot_id
+
+    def _build_client_priority_list(
+        self, preferred_client: Any | None = None
+    ) -> list[Any]:
+        tried_client_ids: set[int] = set()
+        clients: list[Any] = []
+
+        if preferred_client is not None:
+            clients.append(preferred_client)
+            tried_client_ids.add(id(preferred_client))
+
+        for client in self._iter_clients():
+            client_id = id(client)
+            if client_id in tried_client_ids:
+                continue
+            tried_client_ids.add(client_id)
+            clients.append(client)
+
+        return clients
+
+    def _attach_cached_bot_roles(self, groups: list[dict[str, Any]]) -> None:
+        for group in groups:
+            group_id = str(group.get("group_id", "")).strip()
+            group["bot_role"] = self._bot_role_cache.get(group_id, "unknown")
 
     def _iter_clients(self) -> list[Any]:
         clients: list[Any] = []
@@ -261,10 +373,18 @@ class QQGroupInfoCache:
             return default
 
     @staticmethod
+    def _normalize_bot_role(value: Any) -> str:
+        role = str(value or "").strip().lower()
+        if role in {"owner", "admin", "member"}:
+            return role
+        return "unknown"
+
+    @staticmethod
     def _sort_groups(groups: list[dict[str, Any]]) -> list[dict[str, Any]]:
         return sorted(
             groups,
             key=lambda item: (
+                BOT_ROLE_PRIORITY.get(str(item.get("bot_role", "unknown")), 2),
                 not str(item.get("group_id", "")).isdigit(),
                 int(item["group_id"]) if str(item.get("group_id", "")).isdigit() else 0,
                 item.get("group_name", ""),

--- a/page_service.py
+++ b/page_service.py
@@ -53,6 +53,7 @@ class QQAdminPageService:
             "avatar": "",
             "member_count": 0,
             "max_member_count": 0,
+            "bot_role": "unknown",
             "is_default_group": True,
             "config": {
                 FOLLOW_DEFAULT_KEY: False,
@@ -62,6 +63,20 @@ class QQAdminPageService:
 
     async def list_groups(self, force: bool = False) -> list[dict[str, Any]]:
         groups = await self.group_cache.list_groups(force=force)
+        return await self._build_group_entries(groups)
+
+    async def list_groups_with_bot_roles(
+        self, force: bool = False
+    ) -> list[dict[str, Any]]:
+        groups = await self.group_cache.list_groups_with_bot_roles(
+            force_bot_roles=force
+        )
+        return await self._build_group_entries(groups)
+
+    async def _build_group_entries(
+        self,
+        groups: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
         result: list[dict[str, Any]] = [self.get_default_group_entry()]
         stale_group_ids: list[str] = []
 

--- a/pages/settings/app.js
+++ b/pages/settings/app.js
@@ -26,6 +26,7 @@ let allGroups = [];
 let detachContextHandler = null;
 let detachSystemThemeHandler = null;
 let themePreference = loadThemePreference();
+let groupRoleSyncToken = 0;
 
 const els = {
   groupForm: document.getElementById("groupForm"),
@@ -213,6 +214,11 @@ function applyGroupList(groups) {
   filterAndRenderGroups();
 }
 
+function scheduleGroupRoleSync(options = {}) {
+  const requestToken = ++groupRoleSyncToken;
+  void syncGroupRoles(requestToken, options);
+}
+
 function filterGroups() {
   const keyword = String(els.groupSearchInput.value || "")
     .trim()
@@ -267,6 +273,23 @@ async function loadBootstrapData() {
   const data = await api.safeGet("settings/bootstrap");
   bootstrapData = data;
   applyGroupList(data.groups || []);
+}
+
+async function syncGroupRoles(requestToken, options = {}) {
+  const { force = false } = options;
+  try {
+    const groups = await api.safePost("settings/groups/roles", {
+      force: force ? "1" : "0",
+    });
+    if (requestToken !== groupRoleSyncToken) {
+      return;
+    }
+    applyGroupList(groups || []);
+  } catch (error) {
+    if (requestToken === groupRoleSyncToken) {
+      console.debug?.("Failed to sync group bot roles", error);
+    }
+  }
 }
 
 async function refreshGroups() {
@@ -391,6 +414,7 @@ function bindEvents() {
   els.refreshGroupsBtn.addEventListener("click", async () => {
     try {
       await refreshGroups();
+      scheduleGroupRoleSync({ force: true });
       if (currentGroup?.group_id) {
         await loadGroupConfig(currentGroup.group_id);
       }
@@ -465,6 +489,7 @@ async function init() {
 
     bindEvents();
     await loadBootstrapData();
+    scheduleGroupRoleSync();
     await loadGroupConfig(DEFAULT_GROUP_ID);
   } catch (error) {
     const message = error?.message || "页面初始化失败";

--- a/pages/settings/group-view.js
+++ b/pages/settings/group-view.js
@@ -1,3 +1,24 @@
+function buildGroupRoleBadge(group) {
+  const role = String(group?.bot_role || "").toLowerCase();
+  if (role !== "owner" && role !== "admin") {
+    return null;
+  }
+
+  const badge = document.createElement("span");
+  badge.className = `group-role-badge ${role}`;
+
+  const icon = document.createElement("span");
+  icon.className = `group-role-icon ${role}`;
+  icon.textContent = role === "owner" ? "主" : "管";
+  badge.appendChild(icon);
+
+  const text = document.createElement("span");
+  text.textContent = role === "owner" ? "群主" : "管理员";
+  badge.appendChild(text);
+
+  return badge;
+}
+
 export function renderGroupCards({
   root,
   groups,
@@ -40,6 +61,11 @@ export function renderGroupCards({
     name.className = "group-card-name";
     name.textContent = group.group_name || `群 ${group.group_id}`;
     title.appendChild(name);
+
+    const roleBadge = buildGroupRoleBadge(group);
+    if (roleBadge) {
+      title.appendChild(roleBadge);
+    }
 
     main.appendChild(title);
 

--- a/pages/settings/styles.css
+++ b/pages/settings/styles.css
@@ -291,6 +291,48 @@ img {
     white-space: nowrap;
 }
 
+.group-role-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+    font-size: 11px;
+    color: var(--muted);
+}
+
+.group-role-icon {
+    width: 18px;
+    height: 18px;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1;
+    color: white;
+}
+
+.group-role-icon.owner {
+    background: #d1a13a;
+    color: #fff8e2;
+}
+
+.group-role-icon.admin {
+    background: #2a9dbe;
+    color: #eefcff;
+}
+
+[data-theme="dark"] .group-role-icon.owner {
+    background: #b89137;
+    color: #fff6db;
+}
+
+[data-theme="dark"] .group-role-icon.admin {
+    background: #368dab;
+    color: #ebfbff;
+}
+
 .group-card-subline {
     display: flex;
     gap: 8px;

--- a/web.py
+++ b/web.py
@@ -47,6 +47,12 @@ class QQAdminWebController:
                 ["POST"],
                 "Refresh QQ group list",
             ),
+            (
+                "/settings/groups/roles",
+                self.page_refresh_group_roles,
+                ["POST"],
+                "Load bot roles for QQ groups",
+            ),
             ("/settings/group", self.page_get_group, ["GET"], "Load one group config"),
             (
                 "/settings/group",
@@ -111,6 +117,18 @@ class QQAdminWebController:
     async def page_refresh_groups(self):
         return self._jsonify(
             {"ok": True, "data": await self.service.list_groups(force=True)}
+        )
+
+    async def page_refresh_group_roles(self):
+        payload = await self._request().get_json(force=True, silent=True) or {}
+        force = str(payload.get("force", "")).strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+        return self._jsonify(
+            {"ok": True, "data": await self.service.list_groups_with_bot_roles(force)}
         )
 
     async def page_get_group(self):


### PR DESCRIPTION
## Summary by Sourcery

为 QQ 群列表添加机器人角色感知能力，并在设置界面中展示，包括基于角色的排序和显示。

新功能：
- 暴露一个新的 API 端点和服务方法，用于返回包含机器人账号在各个群中角色信息的 QQ 群列表。
- 在设置页面的群组卡片上，为机器人的群主/管理员角色显示可视化徽章。

增强优化：
- 按群组跟踪并缓存机器人角色，以及按客户端缓存机器人 ID，以避免重复的 RPC 调用，同时保持数据在合理范围内的实时性。
- 调整群组排序，使列表中优先显示机器人权限更高的群组（群主/管理员）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add bot role awareness to QQ group listing and surface it in the settings UI, including role-based sorting and display.

New Features:
- Expose a new API endpoint and service method to return QQ group lists enriched with the bot account's role in each group.
- Display a visual badge for the bot's owner/admin role in the group cards on the settings page.

Enhancements:
- Track and cache bot roles per group and bot IDs per client to avoid redundant RPC calls while keeping data reasonably fresh.
- Adjust group sorting to prioritize groups where the bot has higher permissions (owner/admin) in the list.

</details>