### PR TITLE
fix: 修复禁言时间偏移

### DIFF
--- a/config.py
+++ b/config.py
@@ -154,10 +154,10 @@ class PluginConfig(ConfigNode):
 
     def get_ban_time(self, seconds=None) -> int:
         """获取禁言时间"""
-        if not seconds or not isinstance(seconds, int):
+        if seconds is None or not isinstance(seconds, int):
             return random.randint(self.min_ban_time, self.max_ban_time)
         else:
-            return min(max(seconds, self.min_ban_time), self.max_ban_time)
+            return min(max(seconds, 0), 2592000)
 
     @staticmethod
     def _resolve_ban_time_range(random_ban_time: str) -> tuple[int, int]:
@@ -177,9 +177,9 @@ class PluginConfig(ConfigNode):
             return self.get_ban_time(seconds)
 
         min_ban_time, max_ban_time = self._resolve_ban_time_range(random_ban_time)
-        if not seconds or not isinstance(seconds, int):
+        if seconds is None or not isinstance(seconds, int):
             return random.randint(min_ban_time, max_ban_time)
-        return min(max(seconds, min_ban_time), max_ban_time)
+        return min(max(seconds, 0), 2592000)
 
     def build_group_default_config(self) -> dict[str, Any]:
         return {


### PR DESCRIPTION
## Summary by Sourcery

调整封禁时间计算方式，以正确处理显式的零值，并将禁言时长限制在固定的全局范围内。

Bug 修复：
- 确保 0 秒的封禁时间被视为一个有效的显式值，而不是触发随机时长的选择。
- 阻止封禁时长超出全局 0–2592000 秒（30 天）的限制范围，而不受配置范围的影响。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust ban time calculation to correctly handle explicit zero values and cap mute durations within a fixed global range.

Bug Fixes:
- Ensure a ban time of 0 seconds is treated as a valid explicit value instead of triggering random duration selection.
- Prevent ban durations from exceeding the global 0–2592000 second (30 days) bounds regardless of configured ranges.

</details>